### PR TITLE
Enable parallel SMS receiving

### DIFF
--- a/android/src/main/java/me/furtado/smsretriever/GooglePlayServicesHelper.java
+++ b/android/src/main/java/me/furtado/smsretriever/GooglePlayServicesHelper.java
@@ -2,7 +2,7 @@ package me.furtado.smsretriever;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;

--- a/android/src/main/java/me/furtado/smsretriever/PhoneNumberHelper.java
+++ b/android/src/main/java/me/furtado/smsretriever/PhoneNumberHelper.java
@@ -6,9 +6,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.app.FragmentActivity;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.BaseActivityEventListener;

--- a/android/src/main/java/me/furtado/smsretriever/RNSmsRetrieverModule.java
+++ b/android/src/main/java/me/furtado/smsretriever/RNSmsRetrieverModule.java
@@ -1,7 +1,7 @@
 package me.furtado.smsretriever;
 
 import android.app.Activity;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/me/furtado/smsretriever/RNSmsRetrieverPackage.java
+++ b/android/src/main/java/me/furtado/smsretriever/RNSmsRetrieverPackage.java
@@ -1,6 +1,6 @@
 package me.furtado.smsretriever;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;

--- a/android/src/main/java/me/furtado/smsretriever/SmsBroadcastReceiver.java
+++ b/android/src/main/java/me/furtado/smsretriever/SmsBroadcastReceiver.java
@@ -4,7 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.google.android.gms.auth.api.phone.SmsRetriever;
 import com.google.android.gms.common.api.CommonStatusCodes;

--- a/android/src/main/java/me/furtado/smsretriever/SmsHelper.java
+++ b/android/src/main/java/me/furtado/smsretriever/SmsHelper.java
@@ -105,6 +105,13 @@ final class SmsHelper implements SmsBroadcastReceiver.SmsReceiveListener {
                     Log.d(TAG, "SmsRetriver task started successfully");
                 }
             });
+
+            task.addOnFailureListener(new OnFailureListener() {	            
+                @Override	        
+                public void onFailure(@NonNull Exception e) {	
+                    Log.e(TAG, "Failed to start SmsRetriever client", e);	
+                }	
+            });
         };
     }
 


### PR DESCRIPTION
### Description
This PR change the way how receiving multiple SMSs are handled. 

### Problem
The approach used to be sequential - we wait until we receive an SMS and only then start to wait for another one. There is an  issue with this approach, though, when SMSs arrive simultaneously: SMS could arrives between the last SMS was handled and a new handler is deployed. In this case we do not handle it at all.

### Solution
We start N handlers in advance and whenever any of them get's an SMS it just finishes, while the rest are still active.

### Other changes
There is also been an issue (https://github.com/celo-org/celo-monorepo/issues/5209) when one SMS been received multiple times. This was related with adding multiple event listeners and also fixed in this PR.

Fixes: https://github.com/celo-org/celo-monorepo/issues/5209, https://github.com/celo-org/celo-labs/issues/578

